### PR TITLE
Update statistics.md for Oct

### DIFF
--- a/_pages/statistics.md
+++ b/_pages/statistics.md
@@ -42,3 +42,4 @@ permalink: /statistics/
 | 31 | [Cloud Native Linz - April 23 - Secure K8s Deployment and API Management in Azure](https://www.meetup.com/cloud-native-linz/events/298076702/) |  | 22 | in person only |
 | 32 | [Cloud Native Linz - June 25 - Inspecting Running Containers & Observability on the Edge](https://www.meetup.com/cloud-native-linz/events/300982876/) |  | 22 | in person only | 
 | 33 | [Cloud Native Linz - September 18 - OpenTelemetry Errors](https://www.meetup.com/cloud-native-linz/events/302570761/) |  | 22 (remote only) | [Adriana Villela & Reese Lee - Dude, Where’s My Error?](https://www.youtube.com/watch?v=nl7BaeAcv3g) | 
+| 34 | [Cloud Native Linz - October 21 - Beyond k8s and OpenSource Metrics](https://www.meetup.com/cloud-native-linz/events/303406885/) |  | 27 | in person only | 


### PR DESCRIPTION
This pull request includes a small change to the `statistics` page in the `_pages/statistics.md` file. The change adds a new event to the list of Cloud Native Linz meetups.

* [`_pages/statistics.md`](diffhunk://#diff-ad8db5c299dc9f3fc459f62d2a07028f15d94ba55afb733ea94294682b980e81R45): Added the event "Cloud Native Linz - October 21 - Beyond k8s and OpenSource Metrics" to the list of meetups.