### PR TITLE
Add upcoming events section and rename statistics page to events

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -332,3 +332,10 @@
       link: "https://www.youtube.com/watch?v=1mlVzss8bHE"
     - title: "37.2 - Damjan Gjurovski - Designing Zero Trust Systems"
       link: "https://www.youtube.com/watch?v=YV5U2mcohTk"
+
+- id: 38
+  edition: "Cloud Native Linz - Laravel in K8s and Shell Scripting"
+  date: "2025-03-18"
+  event_link: "https://www.meetup.com/cloud-native-linz/events/306377483/"
+  registrations: ""
+  recording: []

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -34,7 +34,7 @@
               <a href="{{ site.baseurl }}/join">Join us!</a>
               <a href="{{ site.baseurl }}/speaker-info">Speaker Info</a>
               <a href="{{ site.baseurl }}/slides">Slides & Content</a>
-              <a href="{{ site.baseurl }}/statistics">Statistics</a>
+              <a href="{{ site.baseurl }}/statistics">Events</a>
               <!--
               <a href="{{ site.baseurl }}/search">Search</a>
               <a href="{{ site.baseurl }}/archive">Archive</a>

--- a/_pages/statistics.md
+++ b/_pages/statistics.md
@@ -1,10 +1,8 @@
 ---
 layout: page
-title: Statistics
+title: Events
 permalink: /statistics/
 ---
-
-### Statistics
 
 <style>
   .date-label {
@@ -21,6 +19,37 @@ permalink: /statistics/
   }
 </style>
 
+{% assign upcoming_events = false %}
+{% for event in site.data.events %}
+  {% assign event_date = event.date | date: "%Y-%m-%d" %}
+  {% assign today = site.time | date: "%Y-%m-%d" %}
+  {% if event_date > today %}
+    {% assign upcoming_events = true %}
+    {% break %}
+  {% endif %}
+{% endfor %}
+
+{% if upcoming_events %}
+### Upcoming Events
+<table width="100%">
+  {% for event in site.data.events %}
+    {% assign event_date = event.date | date: "%Y-%m-%d" %}
+    {% assign today = site.time | date: "%Y-%m-%d" %}
+    {% if event_date > today %}
+      <tr>
+        <td>
+          <span class="date-label">{{ event.date }}</span><br>
+          <a href="{{ event.event_link }}">{{ event.edition }}</a>
+        </td>
+      </tr>
+    {% endif %}
+  {% endfor %}
+</table>
+{% endif %}
+
+
+### Statistics of past events
+
 <table>
   <thead>
     <tr>
@@ -33,6 +62,12 @@ permalink: /statistics/
   </thead>
   <tbody>
     {% for event in site.data.events %}
+      
+    {% assign event_date = event.date | date: "%Y-%m-%d" %}
+    {% assign today = site.time | date: "%Y-%m-%d" %}
+  
+    {% if event_date < today %}
+
     <tr>
       <td>{{ event.id }}</td>
       <td>
@@ -58,6 +93,7 @@ permalink: /statistics/
         {% endif %}
       </td>
     </tr>
+    {% endif %}
     {% endfor %}
   </tbody>
 </table>


### PR DESCRIPTION
Improving the idea of #51 and rendering upcoming events in a dedicated section on top