### PR TITLE
Update event host condition in events.md

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -87,13 +87,9 @@ plugins:
   - jekyll-sitemap # Create a sitemap using the official Jekyll sitemap gem
   - jekyll-feed # Create an Atom feed using the official Jekyll feed gem
   - jekyll-seo-tag
-  - jekyll-paginate
   - jekyll-redirect-from # https://stackoverflow.com/questions/31166747/jekyll-default-page
 
 include: ['_pages']
-
-paginate: 6
-paginate_path: /page:num/
 
 collections:
   slides:

--- a/_pages/events.md
+++ b/_pages/events.md
@@ -67,7 +67,7 @@ permalink: /events/
           {% else %}
             <span class="date-label">{{ event.date }}</span>
           {% endif %}
-          {% if !event.host || event.host != "" %}
+          {% if event.host != nil and event.host != "" %}
             <span class="host-label">hosted by {{ event.host }}</span>
           {% endif %}
           <br>


### PR DESCRIPTION
Fix: #67 

Now, when an event without host is added, the `hosted by` tag won't appear:
![image](https://github.com/user-attachments/assets/fd7bca87-11ab-497e-ad2e-a8a9b5d73d31)
