### PR TITLE
use main branch for github action trigger

### DIFF
--- a/.github/workflows/jekyll-deploy.yml
+++ b/.github/workflows/jekyll-deploy.yml
@@ -9,7 +9,7 @@ name: Deploy Jekyll site to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: [$default-branch]
+    branches: ["main"] 
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
fixes #84 

Had to change to main branch hardcoded as there is no variable to auto-detect the main branch.