### PR TITLE
Add responsive visibility classes for mobile display of talks and slides

### DIFF
--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -30,7 +30,8 @@ layout: default
     <div class="talkdetails">
       <strong>{{ talk.title }}</strong> <span class="label">by {{ talk.speaker }}</span>
       {% if talk.file %}
-        <br><br><object data="{{ talk.file }}" width="100%" height="500" type="application/pdf"></object>
+        <br><br><object data="{{ talk.file }}" width="100%" height="500" type="application/pdf" class="hide-on-mobile"></object>
+        <p><a href="{{ talk.file }}" class="show-on-mobile">📄 Open/Download PDF</a></p>
       {% else %}
         <br><br>The speaker has not provided the slides (yet).
       {% endif %}
@@ -38,7 +39,8 @@ layout: default
         {% assign rec = talk.recording | split: 'v=' %}
         {% assign video_id = rec[1] %} 
         <center>
-        <br><iframe width="560" height="315" src="https://www.youtube.com/embed/{{ video_id }}" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+        <br><iframe width="560" height="315" src="https://www.youtube.com/embed/{{ video_id }}" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen class="hide-on-mobile"></iframe>
+            <iframe src="https://www.youtube.com/embed/{{ video_id }}" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen class="show-on-mobile"></iframe>
         </center>
       {% endif %}
     </div>

--- a/assets/style.scss
+++ b/assets/style.scss
@@ -1290,6 +1290,20 @@ Modules - reusable parts of our design
   margin: 20px 0;
 }
 
+.hide-on-mobile {
+  display: block;
+  @include mobile {
+    display: none;
+  }
+}
+.show-on-mobile {
+  display: none;
+  @include mobile {
+    display: block;
+  }
+}
+
+
 // Settled on moving the import of syntax highlighting to the bottom of the CSS
 // ... Otherwise it really bloats up the top of the CSS file and makes it difficult to find the start
 //@import "highlights";


### PR DESCRIPTION
Closes #79 

as the pdf view is not working really well on android, I decided to remove it and just show a "open/download pdf" link so the native pdf viewer of the OS is used. 