### PR TITLE
Add issue templates for submitting a talk or hosting an event

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-submit-a-talk.yaml
+++ b/.github/ISSUE_TEMPLATE/1-submit-a-talk.yaml
@@ -1,0 +1,57 @@
+name: Submit a Talk
+description: Join Cloud Native Linz as a speaker and share your knowledge with the community.
+title: "[Talk Proposal]: "
+labels: [ "talk-proposal" ]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for your interest in speaking at the Cloud Native Linz meetup! We're excited to hear what you have to share.
+  - type: input
+    id: name
+    attributes:
+      label: What's your name?
+    validations:
+      required: true
+  - type: input
+    id: email
+    attributes:
+      label: Email
+    validations:
+      required: true
+  - type: textarea
+    id: bio
+    attributes:
+      label: Bio
+      description: Tell us a bit about yourself. This will be used to introduce you at the meetup.
+    validations:
+      required: true
+  - type: input
+    id: title
+    attributes:
+      label: Talk Title
+      description: What is the title of your talk?
+    validations:
+      required: true
+  - type: textarea
+    id: abstract
+    attributes:
+      label: Talk Abstract
+      description: Provide a brief description of your talk. We'll use this in the meetup announcement and to help us understand the content and audience.
+    validations:
+      required: true
+  - type: textarea
+    id: takeaways
+    attributes:
+      label: 3 Key Takeaways for the Community
+      description: What are the three main points or lessons that attendees will learn from your talk?
+    validations:
+      required: true
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
+      options:
+        - label: I agree to follow this meetups's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/1-submit-a-talk.yaml
+++ b/.github/ISSUE_TEMPLATE/1-submit-a-talk.yaml
@@ -14,9 +14,9 @@ body:
     validations:
       required: true
   - type: input
-    id: email
     attributes:
-      label: Email
+      label: Contact Details
+      description: How can we reach out to you?
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/1-submit-a-talk.yaml
+++ b/.github/ISSUE_TEMPLATE/1-submit-a-talk.yaml
@@ -14,6 +14,7 @@ body:
     validations:
       required: true
   - type: input
+    id: contact
     attributes:
       label: Contact Details
       description: How can we reach out to you?

--- a/.github/ISSUE_TEMPLATE/2-host-us.yaml
+++ b/.github/ISSUE_TEMPLATE/2-host-us.yaml
@@ -14,9 +14,10 @@ body:
     validations:
       required: true
   - type: input
-    id: email
+    id: contact
     attributes:
-      label: Email
+      label: Contact Details
+      description: How can we reach out to you?
     validations:
       required: true
   - type: input
@@ -25,6 +26,13 @@ body:
       label: Company Name
     validations:
       required: true
+  - type: textarea
+    id: additionalinfo
+    attributes:
+      label: additional Information 
+      description: Is there anything else you would like to share with us?
+    validations:
+      required: false
   - type: checkboxes
     id: terms
     attributes:

--- a/.github/ISSUE_TEMPLATE/2-host-us.yaml
+++ b/.github/ISSUE_TEMPLATE/2-host-us.yaml
@@ -1,0 +1,35 @@
+name: Host Us
+description: Join Cloud Native Linz as a host and help us organize the next meetup.
+title: "[Hosting Request]: "
+labels: [ "hosting-request" ]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for your interest in hosting one of the next Cloud Native Linz meetups! We're excited to get to know you and your company.
+  - type: input
+    id: name
+    attributes:
+      label: What's your name?
+    validations:
+      required: true
+  - type: input
+    id: email
+    attributes:
+      label: Email
+    validations:
+      required: true
+  - type: input
+    id: company
+    attributes:
+      label: Company Name
+    validations:
+      required: true
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
+      options:
+        - label: I agree to follow this meetups's Code of Conduct
+          required: true


### PR DESCRIPTION
First part of #82. As soon as the templates are there and look the way we want, I'll replace the Google form on the website.

I created 2 new issue labels: "talk-proposal" & "hosting-request"