### PR TITLE
add placeholder for MIC talk

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -667,6 +667,8 @@
   registrations: ""
   participants: ""
   talks:
+    - title: "Talk title to be announced soon"
+      speaker: TBD
     - title: "Catch Hackers with Koney: Automated Honeytokens for Cloud-Native Apps"
       speaker: "Mario Kahlhofer"
       image: "https://media.licdn.com/dms/image/v2/C5603AQGT3eD-ton2VA/profile-displayphoto-shrink_800_800/profile-displayphoto-shrink_800_800/0/1584629003058?e=1759968000&v=beta&t=gtvpeaT0vuf3AU1rE3W7EnEU1VzbP9mZTM6ysakFdjQ"


### PR DESCRIPTION
typically we have the first talk from the host.
this PR introduces a placeholder for this for the November edition