### PR TITLE
remove "doors open" from past events

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,5 +12,8 @@ gem "jekyll-datapage-generator"
 gem "sassc", "~> 2.4"
 gem "jekyll-sass-converter", "~> 2.2"
 
+# Required standard library gems for Ruby 3.4+
+gem "bigdecimal"
+
 # Platform-specific gems for better compatibility
-gem "ffi", "~> 1.17", platforms: [:mingw, :x64_mingw, :mswin]
+gem "ffi", "~> 1.17"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ GEM
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     base64 (0.3.0)
+    bigdecimal (4.0.1)
     colorator (1.1.0)
     concurrent-ruby (1.3.5)
     csv (3.3.5)
@@ -12,6 +13,7 @@ GEM
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
     ffi (1.17.2-x86_64-linux-gnu)
+    ffi (1.17.2-x86_64-linux-musl)
     forwardable-extended (2.6.0)
     http_parser.rb (0.8.0)
     i18n (1.14.7)
@@ -76,8 +78,10 @@ GEM
 
 PLATFORMS
   x86_64-linux
+  x86_64-linux-musl
 
 DEPENDENCIES
+  bigdecimal
   ffi (~> 1.17)
   jekyll (~> 4.4)
   jekyll-datapage-generator

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -243,9 +243,9 @@ layout: default
     <div class="event-detail-overlay">
       <div class="event-detail-date">
         {% if event_date == today %}
-          🔥 TODAY - {{ page.date | date: "%B %d, %Y" }} - doors open at {{ page.doors_open }}
+          🔥 TODAY - {{ page.date | date: "%B %d, %Y" }}{% if page.doors_open and page.doors_open != "" %} - doors open at {{ page.doors_open }}{% endif %}
         {% else %}
-          📅 {{ page.date | date: "%B %d, %Y" }} - doors open at {{ page.doors_open }}
+          📅 {{ page.date | date: "%B %d, %Y" }}{% if event_date >= today and page.doors_open and page.doors_open != "" %} - doors open at {{ page.doors_open }}{% endif %}
         {% endif %}
       </div>
       {% if page.host and page.host != "" %}
@@ -278,7 +278,7 @@ layout: default
         <span class="meta-badge success">👥 {{ page.participants }} Participants</span>
       {% endif %}
         <span class="meta-badge">📅 {{ page.date | date: "%a, %B %d, %Y" }}</span>
-        {% if page.doors_open and page.doors_open != "" %}
+        {% if event_date >= today and page.doors_open and page.doors_open != "" %}
         <span class="meta-badge">🕒 Doors open at {{ page.doors_open }}</span>
         {% endif %}
         <span class="meta-badge">📍 Hosted by {{ page.host }}</span>


### PR DESCRIPTION
removes this box for events in the past

<img width="1573" height="1132" alt="image" src="https://github.com/user-attachments/assets/80025f65-e9f8-4cd1-8933-e7106b0b2974" />
